### PR TITLE
New modifier: querystring to jsonbody

### DIFF
--- a/body/querystring2jsonbody/modifier.go
+++ b/body/querystring2jsonbody/modifier.go
@@ -1,0 +1,21 @@
+// Package querystring2jsonbody registers a request modifier for generating parametrized queries
+// to an querystring2jsonbody search service
+package querystring2jsonbody
+
+import (
+	"github.com/google/martian/parse"
+	"github.com/kpacha/martian-components/body/querystring2jsonbody/modifier"
+)
+
+func init() {
+	parse.Register("body.JSONFromQuerystring", FromJSON)
+}
+
+func FromJSON(b []byte) (*parse.Result, error) {
+	msg, err := modifier.FromJSON(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return parse.NewResult(msg, []parse.ModifierType{parse.Request})
+}

--- a/body/querystring2jsonbody/modifier.go
+++ b/body/querystring2jsonbody/modifier.go
@@ -1,5 +1,5 @@
-// Package querystring2jsonbody registers a request modifier for generating parametrized queries
-// to an querystring2jsonbody search service
+// Package querystring2jsonbody registers a request modifier for generating JSON encoded bodies
+// from the querystring params
 package querystring2jsonbody
 
 import (

--- a/body/querystring2jsonbody/modifier/modifier.go
+++ b/body/querystring2jsonbody/modifier/modifier.go
@@ -1,5 +1,5 @@
-// Package modifier exposes a request modifier for generating parametrized queries
-// to an elastic search service
+// Package modifier exposes a request modifier for generating JSON encoded bodies
+// from the querystring params
 package modifier
 
 import (

--- a/body/querystring2jsonbody/modifier/modifier.go
+++ b/body/querystring2jsonbody/modifier/modifier.go
@@ -1,0 +1,65 @@
+// Package modifier exposes a request modifier for generating parametrized queries
+// to an elastic search service
+package modifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"text/template"
+)
+
+type Config struct {
+	KeysToExtract []string `json:"keys_to_extract"`
+	Template      string   `json:"template"`
+	Method        string   `json:"method"`
+}
+
+type Query2BodyModifier struct {
+	keysToExtract []string
+	template      *template.Template
+	method        string
+}
+
+func (m *Query2BodyModifier) ModifyRequest(req *http.Request) error {
+	query := req.URL.Query()
+
+	buf := new(bytes.Buffer)
+	if err := m.template.Execute(buf, query); err != nil {
+		return err
+	}
+
+	for _, k := range m.keysToExtract {
+		query.Del(k)
+	}
+
+	req.Method = m.method
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.ContentLength = int64(buf.Len())
+	req.Body = ioutil.NopCloser(buf)
+	req.URL.RawQuery = query.Encode()
+
+	return nil
+}
+
+func FromJSON(b []byte) (*Query2BodyModifier, error) {
+	cfg := &Config{}
+	if err := json.Unmarshal(b, cfg); err != nil {
+		return nil, err
+	}
+
+	tmpl, err := template.New("query2jsonbody_modifier").Parse(cfg.Template)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Method == "" {
+		cfg.Method = http.MethodPost
+	}
+
+	return &Query2BodyModifier{
+		keysToExtract: cfg.KeysToExtract,
+		template:      tmpl,
+		method:        cfg.Method,
+	}, nil
+}

--- a/body/querystring2jsonbody/modifier/modifier.go
+++ b/body/querystring2jsonbody/modifier/modifier.go
@@ -34,7 +34,9 @@ func (m *Query2BodyModifier) ModifyRequest(req *http.Request) error {
 		query.Del(k)
 	}
 
-	req.Method = m.method
+	if m.method != "" {
+		req.Method = m.method
+	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	req.ContentLength = int64(buf.Len())
 	req.Body = ioutil.NopCloser(buf)
@@ -52,9 +54,6 @@ func FromJSON(b []byte) (*Query2BodyModifier, error) {
 	tmpl, err := template.New("query2jsonbody_modifier").Parse(cfg.Template)
 	if err != nil {
 		return nil, err
-	}
-	if cfg.Method == "" {
-		cfg.Method = http.MethodPost
 	}
 
 	return &Query2BodyModifier{

--- a/body/querystring2jsonbody/modifier/modifier_test.go
+++ b/body/querystring2jsonbody/modifier/modifier_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestESQueryModifier(t *testing.T) {
-	cfg := `{"keys_to_extract":["foo","x"],"template":"{\"foo\":\"{{index .foo 0}}\",\"bar\":\"{{index .bar 0}}\",\"x\":\"{{index .x 0 }}\"}"}`
+	cfg := `{"keys_to_extract":["foo","x"],"template":"{\"foo\":\"{{index .foo 0}}\",\"bar\":\"{{index .bar 0}}\",\"x\":\"{{index .x 0 }}\"}", "method":"POST"}`
 	modifier, err := FromJSON([]byte(cfg))
 	if err != nil {
 		t.Error(err)

--- a/body/querystring2jsonbody/modifier/modifier_test.go
+++ b/body/querystring2jsonbody/modifier/modifier_test.go
@@ -1,0 +1,91 @@
+package modifier
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestESQueryModifier(t *testing.T) {
+	cfg := `{"keys_to_extract":["foo","x"],"template":"{\"foo\":\"{{index .foo 0}}\",\"bar\":\"{{index .bar 0}}\",\"x\":\"{{index .x 0 }}\"}"}`
+	modifier, err := FromJSON([]byte(cfg))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Error("wrong method:", r.Method)
+		}
+		query := r.URL.Query()
+		for _, k := range []string{"foo", "x"} {
+			if query.Get(k) != "" {
+				t.Error("the param", k, "is present in the querystring")
+			}
+		}
+		for _, k := range []string{"bar", "y", "z"} {
+			if query.Get(k) == "" {
+				t.Error("the param", k, "is not present in the querystring")
+			}
+		}
+
+		if ct := r.Header.Get("Content-Type"); ct != "application/json; charset=UTF-8" {
+			t.Errorf("unexpected content-tupe: %s", ct)
+		}
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		r.Body.Close()
+
+		if string(body) != `{"foo":"1","bar":"foobar","x":"booo"}` {
+			t.Errorf("unexpected response: %s", string(body))
+		}
+	}))
+
+	URL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	query := URL.Query()
+	query.Add("foo", "1")
+	query.Add("bar", "foobar")
+	query.Add("x", "booo")
+	query.Add("y", "1")
+	query.Add("z", "1")
+	URL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest("GET", URL.String(), ioutil.NopCloser(bytes.NewReader([]byte{})))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := modifier.ModifyRequest(req); err != nil {
+		t.Error(err)
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Error("unexpected status code:", resp.StatusCode)
+		return
+	}
+}
+
+func TestESQueryModifier_badDSL(t *testing.T) {
+	if _, err := FromJSON([]byte(`"x"]}`)); err == nil {
+		t.Errorf("error expected")
+	}
+}


### PR DESCRIPTION
this PR introduces a new modifier able to extract values from the querystring and use them to generate a new JSON-encoded body.

Sample config:
```
{
	"keys_to_extract": ["foo", "x"],
	"template": "{\"foo\":\"{{index .foo 0}}\",\"bar\":\"{{index .bar 0}}\",\"x\":\"{{index .x 0 }}\"}",
	"method": "PUT"
}
```

with this config, a `"body.JSONFromQuerystring"` modifier will:
- use the first value of the `foo`, `bar` and `x ` querystring to create the request body
- remove the querystring keys `foo` and `x`
- set the request method to `PUT` 